### PR TITLE
Explore random forest models

### DIFF
--- a/docs/notebooks/compare_ensemble_models.ipynb
+++ b/docs/notebooks/compare_ensemble_models.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.model_selection import cross_val_score, train_test_split\n",
     "\n",
     "from fowt_ml.datasets import convert_mat_to_df\n",
     "from fowt_ml.ensemble import EnsembleModel"
@@ -123,14 +123,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 24.5 s, sys: 638 ms, total: 25.1 s\n",
-      "Wall time: 26.2 s\n"
+      "CPU times: user 22.2 s, sys: 529 ms, total: 22.7 s\n",
+      "Wall time: 23.5 s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "(5, -3.481590243017996, 0.004214234873016776)"
+       "(5, -3.4828061390322005, 0.005965294435464364)"
       ]
      },
      "execution_count": 5,
@@ -140,7 +140,7 @@
    ],
    "source": [
     "%%time\n",
-    "scores = model.cross_val_score(X_train, Y_train, scoring=\"neg_root_mean_squared_error\")\n",
+    "scores = cross_val_score(model.estimator, X_train, Y_train, scoring=\"neg_root_mean_squared_error\")\n",
     "len(scores), scores.mean(), scores.std()"
    ]
   },
@@ -160,7 +160,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/fnattino/Projects/HybridLabs/FOWT-ML/src/fowt_ml/ensemble.py:65: UserWarning: Setting `bootstrap=True` and `oob_score=<function EnsembleModel.oob_score.<locals>.score_func at 0x16b59f240>`\n",
+      "/Users/fnattino/Projects/HybridLabs/FOWT-ML/src/fowt_ml/ensemble.py:49: UserWarning: Setting `bootstrap=True` and `oob_score=<function EnsembleModel.oob_score.<locals>.score_func at 0x16b8fae80>`\n",
       "  warnings.warn(f\"Setting `bootstrap=True` and `oob_score={oob_score}`\")\n"
      ]
     },
@@ -168,14 +168,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 8.2 s, sys: 640 ms, total: 8.84 s\n",
-      "Wall time: 9.04 s\n"
+      "CPU times: user 7.63 s, sys: 646 ms, total: 8.28 s\n",
+      "Wall time: 8.6 s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "-3.4801829178744947"
+       "-3.480819620430942"
       ]
      },
      "execution_count": 6,
@@ -204,7 +204,7 @@
     {
      "data": {
       "text/plain": [
-       "{'neg_root_mean_squared_error': -3.4859696856839104, 'r2': 0.1218746787172302}"
+       "{'neg_root_mean_squared_error': -3.48854898913557, 'r2': 0.12065774081363125}"
       ]
      },
      "execution_count": 7,
@@ -229,23 +229,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def cross_val_score(estimator, X, y, scoring, **kwargs):\n",
+    "def run_cross_val_score(estimator, X, y, scoring, **kwargs):\n",
     "    model = EnsembleModel(estimator, **kwargs)\n",
-    "    cv_score = model.cross_val_score(X, y, scoring=scoring)\n",
+    "    cv_score = cross_val_score(model.estimator, X, y, scoring=scoring)\n",
     "    oob_score = model.oob_score(X, y, scoring=scoring)\n",
     "    print(f\"CV score: {cv_score.mean()} ; OOB score: {oob_score}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/fnattino/Projects/HybridLabs/FOWT-ML/src/fowt_ml/ensemble.py:65: UserWarning: Setting `bootstrap=True` and `oob_score=<function EnsembleModel.oob_score.<locals>.score_func at 0x16a84e160>`\n",
+      "/Users/fnattino/Projects/HybridLabs/FOWT-ML/src/fowt_ml/ensemble.py:49: UserWarning: Setting `bootstrap=True` and `oob_score=<function EnsembleModel.oob_score.<locals>.score_func at 0x16b8fb060>`\n",
       "  warnings.warn(f\"Setting `bootstrap=True` and `oob_score={oob_score}`\")\n"
      ]
     },
@@ -253,14 +253,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CV score: -3.4817418084741947 ; OOB score: -3.4830183651890376\n"
+      "CV score: -3.481252853449478 ; OOB score: -3.48101482544245\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/fnattino/Projects/HybridLabs/FOWT-ML/src/fowt_ml/ensemble.py:65: UserWarning: Setting `bootstrap=True` and `oob_score=<function EnsembleModel.oob_score.<locals>.score_func at 0x1696cd8a0>`\n",
+      "/Users/fnattino/Projects/HybridLabs/FOWT-ML/src/fowt_ml/ensemble.py:49: UserWarning: Setting `bootstrap=True` and `oob_score=<function EnsembleModel.oob_score.<locals>.score_func at 0x16b8fade0>`\n",
       "  warnings.warn(f\"Setting `bootstrap=True` and `oob_score={oob_score}`\")\n"
      ]
     },
@@ -268,14 +268,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CV score: -3.533564568472392 ; OOB score: -3.531636754474704\n"
+      "CV score: -3.5334720930453885 ; OOB score: -3.5350612318601287\n"
      ]
     }
    ],
    "source": [
     "params = {\"max_depth\": 9, \"max_samples\": 10_000, \"bootstrap\": True, \"n_estimators\": 50}\n",
-    "cross_val_score(\"RandomForest\", X_train, Y_train, \"neg_root_mean_squared_error\", **params)\n",
-    "cross_val_score(\"ExtraTrees\", X_train, Y_train, \"neg_root_mean_squared_error\", **params)"
+    "run_cross_val_score(\"RandomForest\", X_train, Y_train, \"neg_root_mean_squared_error\", **params)\n",
+    "run_cross_val_score(\"ExtraTrees\", X_train, Y_train, \"neg_root_mean_squared_error\", **params)"
    ]
   }
  ],

--- a/docs/notebooks/compare_ensemble_models.ipynb
+++ b/docs/notebooks/compare_ensemble_models.ipynb
@@ -103,7 +103,7 @@
    "outputs": [],
    "source": [
     "model = EnsembleModel(\n",
-    "    estimator=\"RandomForest\", max_depth=9, max_samples=10_000, n_estimators=50\n",
+    "    estimator=\"RandomForest\", max_depth=9, bootstrap=True, max_samples=10_000, n_estimators=50\n",
     ")"
    ]
   },
@@ -123,14 +123,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 22.9 s, sys: 564 ms, total: 23.5 s\n",
-      "Wall time: 24.3 s\n"
+      "CPU times: user 24.5 s, sys: 638 ms, total: 25.1 s\n",
+      "Wall time: 26.2 s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "(5, -3.4812604563320386, 0.005142800724868689)"
+       "(5, -3.481590243017996, 0.004214234873016776)"
       ]
      },
      "execution_count": 5,
@@ -148,7 +148,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can then train the model on the full training dataset, and get the ultimate score on the test set: "
+    "We do the same but using out-of-bag samples to estimate the generalization score (which should be cheaper):"
    ]
   },
   {
@@ -157,9 +157,25 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/fnattino/Projects/HybridLabs/FOWT-ML/src/fowt_ml/ensemble.py:65: UserWarning: Setting `bootstrap=True` and `oob_score=<function EnsembleModel.oob_score.<locals>.score_func at 0x16b59f240>`\n",
+      "  warnings.warn(f\"Setting `bootstrap=True` and `oob_score={oob_score}`\")\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 8.2 s, sys: 640 ms, total: 8.84 s\n",
+      "Wall time: 9.04 s\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
-       "-3.487296951081186"
+       "-3.4801829178744947"
       ]
      },
      "execution_count": 6,
@@ -168,8 +184,98 @@
     }
    ],
    "source": [
-    "model.fit(X_train, Y_train)\n",
-    "model.score(X_test, Y_test, scoring=\"neg_root_mean_squared_error\")\n"
+    "%%time\n",
+    "score = model.oob_score(X_train, Y_train, scoring=\"neg_root_mean_squared_error\")\n",
+    "score"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally we train the model on the full training dataset, and get one or more scores on the test set: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'neg_root_mean_squared_error': -3.4859696856839104, 'r2': 0.1218746787172302}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.calculate_score(X_train, Y_train, X_test, Y_test, scoring=[\"neg_root_mean_squared_error\", \"r2\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Include everything in a function to test both random forest and extremely randomized trees:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def cross_val_score(estimator, X, y, scoring, **kwargs):\n",
+    "    model = EnsembleModel(estimator, **kwargs)\n",
+    "    cv_score = model.cross_val_score(X, y, scoring=scoring)\n",
+    "    oob_score = model.oob_score(X, y, scoring=scoring)\n",
+    "    print(f\"CV score: {cv_score.mean()} ; OOB score: {oob_score}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/fnattino/Projects/HybridLabs/FOWT-ML/src/fowt_ml/ensemble.py:65: UserWarning: Setting `bootstrap=True` and `oob_score=<function EnsembleModel.oob_score.<locals>.score_func at 0x16a84e160>`\n",
+      "  warnings.warn(f\"Setting `bootstrap=True` and `oob_score={oob_score}`\")\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CV score: -3.4817418084741947 ; OOB score: -3.4830183651890376\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/fnattino/Projects/HybridLabs/FOWT-ML/src/fowt_ml/ensemble.py:65: UserWarning: Setting `bootstrap=True` and `oob_score=<function EnsembleModel.oob_score.<locals>.score_func at 0x1696cd8a0>`\n",
+      "  warnings.warn(f\"Setting `bootstrap=True` and `oob_score={oob_score}`\")\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CV score: -3.533564568472392 ; OOB score: -3.531636754474704\n"
+     ]
+    }
+   ],
+   "source": [
+    "params = {\"max_depth\": 9, \"max_samples\": 10_000, \"bootstrap\": True, \"n_estimators\": 50}\n",
+    "cross_val_score(\"RandomForest\", X_train, Y_train, \"neg_root_mean_squared_error\", **params)\n",
+    "cross_val_score(\"ExtraTrees\", X_train, Y_train, \"neg_root_mean_squared_error\", **params)"
    ]
   }
  ],

--- a/docs/notebooks/explore_random_forest_models.ipynb
+++ b/docs/notebooks/explore_random_forest_models.ipynb
@@ -1,0 +1,197 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.model_selection import train_test_split\n",
+    "\n",
+    "from fowt_ml.datasets import convert_mat_to_df\n",
+    "from fowt_ml.ensemble import EnsembleModel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Fit a Random Forest Estimator"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load and fix the dataset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_path = \"../../data/exp699_032024_TUDelft/exp699.mat\"\n",
+    "data = convert_mat_to_df(data_path, \"exp699\")\n",
+    "data[\"wind_speed\"] = 4.  # add attribute as a feature"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Define targets and predictors, then split them into train and test data:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "target_labels = [\n",
+    "    'acc_tb_meas3[0]',\n",
+    "    'acc_tb_meas3[1]',\n",
+    "    'acc_tb_meas3[2]',\n",
+    "    'acc_tt_meas3[0]',\n",
+    "    'acc_tt_meas3[1]',\n",
+    "    'acc_tt_meas3[2]',\n",
+    "    'force_aero_est6[0]',\n",
+    "    'force_aero_est6[1]',\n",
+    "    'force_aero_est6[2]',\n",
+    "    'force_aero_est6[3]',\n",
+    "    'force_aero_est6[4]',\n",
+    "    'force_aero_est6[5]',\n",
+    "    'force_tt_meas6[0]',\n",
+    "    'force_tt_meas6[1]',\n",
+    "    'force_tt_meas6[2]',\n",
+    "    'force_tt_meas6[3]',\n",
+    "    'force_tt_meas6[4]',\n",
+    "    'force_tt_meas6[5]',\n",
+    "]\n",
+    "predictor_labels = [\n",
+    "    'pos_act6[0]',\n",
+    "    'pos_act6[1]',\n",
+    "    'pos_act6[2]',\n",
+    "    'pos_act6[3]',\n",
+    "    'pos_act6[4]',\n",
+    "    'pos_act6[5]',\n",
+    "    'spd_rot_act',\n",
+    "    'wind_speed',\n",
+    "]\n",
+    "\n",
+    "X = data[predictor_labels]\n",
+    "Y = data[target_labels]\n",
+    "\n",
+    "# should we shuffle data here?\n",
+    "X_train, X_test, Y_train, Y_test = train_test_split(X, Y, test_size=0.25, random_state=123)  # shuffle = True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's instantiate a model by defining a few parameters: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = EnsembleModel(\n",
+    "    estimator=\"RandomForest\", max_depth=9, max_samples=10_000, n_estimators=50\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We get an estimate of the model performance by running cross validation (CV) - the default is to run k-fold CV, with `k=5`: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 22.9 s, sys: 564 ms, total: 23.5 s\n",
+      "Wall time: 24.3 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(5, -3.4812604563320386, 0.005142800724868689)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "scores = model.cross_val_score(X_train, Y_train, scoring=\"neg_root_mean_squared_error\")\n",
+    "len(scores), scores.mean(), scores.std()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can then train the model on the full training dataset, and get the ultimate score on the test set: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "-3.487296951081186"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.fit(X_train, Y_train)\n",
+    "model.score(X_test, Y_test, scoring=\"neg_root_mean_squared_error\")\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "hybridlabs",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "numpy",
     "pandas",
     "pyyaml",
+    "scikit-learn>=1.5",
 ]
 description = "Machine learning (ML) kit for floating offshore wind turbines (FOWT)"
 keywords = ["wind turbine"," machine learning"," NN"," ML"," FOWT"]

--- a/src/fowt_ml/ensemble.py
+++ b/src/fowt_ml/ensemble.py
@@ -56,10 +56,14 @@ class EnsembleModel:
             oob_score = True
         else:
             scorer = get_scorer(scoring)
-            oob_score = scorer._score_func
+
+            def score_func(y, y_pred, **kwargs):
+                return scorer._sign * scorer._score_func(y, y_pred, **kwargs)
+
+            oob_score = score_func
         if not (self.estimator.bootstrap and self.estimator.oob_score):
             warnings.warn(f"Setting `bootstrap=True` and `oob_score={oob_score}`")
-            self.estimator.set_params({"bootstrap": True, "oob_score": oob_score})
+            self.estimator.set_params(bootstrap=True, oob_score=oob_score)
         self.estimator.fit(X, y)
         return self.estimator.oob_score_
 

--- a/src/fowt_ml/ensemble.py
+++ b/src/fowt_ml/ensemble.py
@@ -2,19 +2,13 @@
 import warnings
 from collections.abc import Iterable
 from typing import Any
-from typing import Protocol
-from typing import Self
 from numpy.typing import ArrayLike
+from sklearn.base import BaseEstimator
 from sklearn.ensemble import ExtraTreesRegressor
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.metrics import check_scoring
 from sklearn.metrics import get_scorer
 from sklearn.model_selection import cross_val_score
-
-
-class Estimator(Protocol):
-    def fit(self, X: ArrayLike, y: ArrayLike) -> Self: ...  # noqa: D102
-    def predict(self, X: ArrayLike) -> ArrayLike: ...  # noqa: D102
 
 
 class EnsembleModel:
@@ -25,7 +19,9 @@ class EnsembleModel:
         "RandomForest": RandomForestRegressor,
     }
 
-    def __init__(self, estimator: str | Estimator, **kwargs: dict[str, Any]) -> None:
+    def __init__(
+        self, estimator: str | BaseEstimator, **kwargs: dict[str, Any]
+    ) -> None:
         if isinstance(estimator, str):
             if estimator not in self.ENSEMBLE_REGRESSORS:
                 raise ValueError(

--- a/src/fowt_ml/ensemble.py
+++ b/src/fowt_ml/ensemble.py
@@ -1,0 +1,60 @@
+from typing import Any, Protocol, Self
+
+from numpy.typing import ArrayLike
+from sklearn.ensemble import ExtraTreesRegressor, RandomForestRegressor
+from sklearn.metrics import get_scorer
+from sklearn.model_selection import cross_val_score
+
+
+class Estimator(Protocol):
+    def fit(self, X: ArrayLike, y: ArrayLike) -> Self: ...
+    def predict(self, X: ArrayLike) -> ArrayLike: ...
+
+
+ENSEMBLE_REGRESSORS = {
+    "ExtraTrees": ExtraTreesRegressor,
+    "RandomForest": RandomForestRegressor,
+}
+
+
+class EnsembleModel:
+    """Class to handle random forest models and metrics for comparison."""
+    def __init__(self, estimator: str | Estimator, **kwargs: dict[str, Any]) -> None:
+        if isinstance(estimator, str):
+            if estimator not in ENSEMBLE_REGRESSORS:
+                raise ValueError(f"Available estimators: {ENSEMBLE_REGRESSORS.keys()}")
+            self.estimator = ENSEMBLE_REGRESSORS[estimator](**kwargs)
+        else:
+            self.estimator = estimator.set_params(**kwargs)
+
+        self._is_fitted = False
+
+    def cross_val_score(self, X: ArrayLike, y: ArrayLike, cv: int | None = None, scoring: str | None = None):
+        """ Get Cross Validation score.
+
+        Scoring paramers overview: https://scikit-learn.org/stable/modules/model_evaluation.html#string-name-scorers
+        """
+        return cross_val_score(self.estimator, X, y, cv=cv, scoring=scoring)
+
+    def fit(self, X: ArrayLike, y: ArrayLike, sample_weight: ArrayLike = None) -> None:
+        """ Fit an estimator. """
+        self.estimator.fit(X, y, sample_weight=sample_weight)
+        self._is_fitted = True
+
+    def predict(self, X: ArrayLike) -> ArrayLike:
+        """ Predict with a fitted estimator. """
+        if not self._is_fitted:
+            raise RuntimeError("Run `model.fit(...)` first!")
+        return self.estimator.predict(X)
+
+    def score(self, X: ArrayLike, y: ArrayLike, scoring: str | None = None) -> float | ArrayLike:
+        """ Calculate score for a fitted estimator.
+
+        If "scoring" is not provided, directly use the `.score()` method of the estimator.
+        """
+        if scoring is None:
+            score = self.estimator.score(X, y)
+        else:
+            scorer = get_scorer(scoring)
+            score = scorer(self.estimator, X, y)
+        return score

--- a/src/fowt_ml/ensemble.py
+++ b/src/fowt_ml/ensemble.py
@@ -1,11 +1,12 @@
 # ruff: noqa: N803
+from collections.abc import Iterable
 from typing import Any
 from typing import Protocol
 from typing import Self
 from numpy.typing import ArrayLike
 from sklearn.ensemble import ExtraTreesRegressor
 from sklearn.ensemble import RandomForestRegressor
-from sklearn.metrics import get_scorer
+from sklearn.metrics import check_scoring
 from sklearn.model_selection import cross_val_score
 
 
@@ -14,31 +15,30 @@ class Estimator(Protocol):
     def predict(self, X: ArrayLike) -> ArrayLike: ...  # noqa: D102
 
 
-ENSEMBLE_REGRESSORS = {
-    "ExtraTrees": ExtraTreesRegressor,
-    "RandomForest": RandomForestRegressor,
-}
-
-
 class EnsembleModel:
     """Class to handle random forest models and metrics for comparison."""
 
+    ENSEMBLE_REGRESSORS = {
+        "ExtraTrees": ExtraTreesRegressor,
+        "RandomForest": RandomForestRegressor,
+    }
+
     def __init__(self, estimator: str | Estimator, **kwargs: dict[str, Any]) -> None:
         if isinstance(estimator, str):
-            if estimator not in ENSEMBLE_REGRESSORS:
-                raise ValueError(f"Available estimators: {ENSEMBLE_REGRESSORS.keys()}")
-            self.estimator = ENSEMBLE_REGRESSORS[estimator](**kwargs)
+            if estimator not in self.ENSEMBLE_REGRESSORS:
+                raise ValueError(
+                    f"Available estimators: {self.ENSEMBLE_REGRESSORS.keys()}"
+                )
+            self.estimator = self.ENSEMBLE_REGRESSORS[estimator](**kwargs)
         else:
             self.estimator = estimator.set_params(**kwargs)
-
-        self._is_fitted = False
 
     def cross_val_score(
         self,
         X: ArrayLike,
         y: ArrayLike,
         cv: int | None = None,
-        scoring: str | None = None,
+        scoring: str | Iterable | None = None,
     ) -> float | ArrayLike:
         """Get Cross Validation score.
 
@@ -46,28 +46,18 @@ class EnsembleModel:
         """  # noqa: E501
         return cross_val_score(self.estimator, X, y, cv=cv, scoring=scoring)
 
-    def fit(self, X: ArrayLike, y: ArrayLike, sample_weight: ArrayLike = None) -> None:
-        """Fit an estimator."""
-        self.estimator.fit(X, y, sample_weight=sample_weight)
-        self._is_fitted = True
-
-    def predict(self, X: ArrayLike) -> ArrayLike:
-        """Predict with a fitted estimator."""
-        if not self._is_fitted:
-            raise RuntimeError("Run `model.fit(...)` first!")
-        return self.estimator.predict(X)
-
-    def score(
-        self, X: ArrayLike, y: ArrayLike, scoring: str | None = None
+    def calculate_score(
+        self,
+        X_train: ArrayLike,
+        y_train: ArrayLike,
+        X_test: ArrayLike,
+        y_test: ArrayLike,
+        scoring: str | Iterable | None = None,
     ) -> float | ArrayLike:
-        """Calculate score for a fitted estimator.
+        """Fit and calculate a score.
 
-        If "scoring" is not provided, directly use the `.score()` method of the
-        estimator.
-        """
-        if scoring is None:
-            score = self.estimator.score(X, y)
-        else:
-            scorer = get_scorer(scoring)
-            score = scorer(self.estimator, X, y)
-        return score
+        Scoring paramers overview: https://scikit-learn.org/stable/modules/model_evaluation.html#string-name-scorers
+        """  # noqa: E501
+        self.estimator.fit(X_train, y_train)
+        scorer = check_scoring(self.estimator, scoring=scoring)
+        return scorer(self.estimator, X_test, y_test)

--- a/src/fowt_ml/ensemble.py
+++ b/src/fowt_ml/ensemble.py
@@ -8,7 +8,6 @@ from sklearn.ensemble import ExtraTreesRegressor
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.metrics import check_scoring
 from sklearn.metrics import get_scorer
-from sklearn.model_selection import cross_val_score
 
 
 class EnsembleModel:
@@ -30,7 +29,6 @@ class EnsembleModel:
             self.estimator = self.ENSEMBLE_REGRESSORS[estimator](**kwargs)
         else:
             self.estimator = estimator.set_params(**kwargs)
-
 
     def oob_score(
         self, X: ArrayLike, y: ArrayLike, scoring: str | None = None

--- a/src/fowt_ml/ensemble.py
+++ b/src/fowt_ml/ensemble.py
@@ -22,6 +22,7 @@ ENSEMBLE_REGRESSORS = {
 
 class EnsembleModel:
     """Class to handle random forest models and metrics for comparison."""
+
     def __init__(self, estimator: str | Estimator, **kwargs: dict[str, Any]) -> None:
         if isinstance(estimator, str):
             if estimator not in ENSEMBLE_REGRESSORS:
@@ -33,8 +34,11 @@ class EnsembleModel:
         self._is_fitted = False
 
     def cross_val_score(
-            self, X: ArrayLike, y: ArrayLike, cv: int | None = None,
-            scoring: str | None = None
+        self,
+        X: ArrayLike,
+        y: ArrayLike,
+        cv: int | None = None,
+        scoring: str | None = None,
     ) -> float | ArrayLike:
         """Get Cross Validation score.
 
@@ -54,7 +58,7 @@ class EnsembleModel:
         return self.estimator.predict(X)
 
     def score(
-            self, X: ArrayLike, y: ArrayLike, scoring: str | None = None
+        self, X: ArrayLike, y: ArrayLike, scoring: str | None = None
     ) -> float | ArrayLike:
         """Calculate score for a fitted estimator.
 

--- a/src/fowt_ml/ensemble.py
+++ b/src/fowt_ml/ensemble.py
@@ -31,18 +31,6 @@ class EnsembleModel:
         else:
             self.estimator = estimator.set_params(**kwargs)
 
-    def cross_val_score(
-        self,
-        X: ArrayLike,
-        y: ArrayLike,
-        cv: int | None = None,
-        scoring: str | None = None,
-    ) -> float | ArrayLike:
-        """Get Cross Validation score.
-
-        Scoring paramers overview: https://scikit-learn.org/stable/modules/model_evaluation.html#string-name-scorers
-        """  # noqa: E501
-        return cross_val_score(self.estimator, X, y, cv=cv, scoring=scoring)
 
     def oob_score(
         self, X: ArrayLike, y: ArrayLike, scoring: str | None = None

--- a/src/fowt_ml/ensemble.py
+++ b/src/fowt_ml/ensemble.py
@@ -1,14 +1,17 @@
-from typing import Any, Protocol, Self
-
+# ruff: noqa: N803
+from typing import Any
+from typing import Protocol
+from typing import Self
 from numpy.typing import ArrayLike
-from sklearn.ensemble import ExtraTreesRegressor, RandomForestRegressor
+from sklearn.ensemble import ExtraTreesRegressor
+from sklearn.ensemble import RandomForestRegressor
 from sklearn.metrics import get_scorer
 from sklearn.model_selection import cross_val_score
 
 
 class Estimator(Protocol):
-    def fit(self, X: ArrayLike, y: ArrayLike) -> Self: ...
-    def predict(self, X: ArrayLike) -> ArrayLike: ...
+    def fit(self, X: ArrayLike, y: ArrayLike) -> Self: ...  # noqa: D102
+    def predict(self, X: ArrayLike) -> ArrayLike: ...  # noqa: D102
 
 
 ENSEMBLE_REGRESSORS = {
@@ -29,28 +32,34 @@ class EnsembleModel:
 
         self._is_fitted = False
 
-    def cross_val_score(self, X: ArrayLike, y: ArrayLike, cv: int | None = None, scoring: str | None = None):
-        """ Get Cross Validation score.
+    def cross_val_score(
+            self, X: ArrayLike, y: ArrayLike, cv: int | None = None,
+            scoring: str | None = None
+    ) -> float | ArrayLike:
+        """Get Cross Validation score.
 
         Scoring paramers overview: https://scikit-learn.org/stable/modules/model_evaluation.html#string-name-scorers
-        """
+        """  # noqa: E501
         return cross_val_score(self.estimator, X, y, cv=cv, scoring=scoring)
 
     def fit(self, X: ArrayLike, y: ArrayLike, sample_weight: ArrayLike = None) -> None:
-        """ Fit an estimator. """
+        """Fit an estimator."""
         self.estimator.fit(X, y, sample_weight=sample_weight)
         self._is_fitted = True
 
     def predict(self, X: ArrayLike) -> ArrayLike:
-        """ Predict with a fitted estimator. """
+        """Predict with a fitted estimator."""
         if not self._is_fitted:
             raise RuntimeError("Run `model.fit(...)` first!")
         return self.estimator.predict(X)
 
-    def score(self, X: ArrayLike, y: ArrayLike, scoring: str | None = None) -> float | ArrayLike:
-        """ Calculate score for a fitted estimator.
+    def score(
+            self, X: ArrayLike, y: ArrayLike, scoring: str | None = None
+    ) -> float | ArrayLike:
+        """Calculate score for a fitted estimator.
 
-        If "scoring" is not provided, directly use the `.score()` method of the estimator.
+        If "scoring" is not provided, directly use the `.score()` method of the
+        estimator.
         """
         if scoring is None:
             score = self.estimator.score(X, y)

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -48,20 +48,6 @@ class TestEnsembleModel:
         model = EnsembleModel(estimator=estimator)
         assert isinstance(model.estimator, RandomForestRegressor)
 
-    def test_cross_val_score_results_have_correct_shape(self, regression_data):
-        x, y = regression_data
-        model = EnsembleModel(estimator="RandomForest")
-        n_folds = 3  # default is to use k-fold CV, where k is the number of folds
-        scores = model.cross_val_score(x, y, cv=n_folds)
-        assert len(scores) == n_folds
-
-    def test_cross_val_score_can_accept_custom_scoring(self, regression_data):
-        x, y = regression_data
-        model = EnsembleModel(estimator="RandomForest")
-        scores = model.cross_val_score(x, y, scoring="neg_root_mean_squared_error")
-        # score is negative to make it such that higher is better
-        assert all(scores < 0)
-
     def test_oob_score_works_with_default_scoring(self, regression_data):
         x, y = regression_data
         # oob_score=True means that r2 scoring is used

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -1,0 +1,118 @@
+import pytest
+from sklearn.datasets import make_regression
+from sklearn.ensemble import ExtraTreesRegressor
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.model_selection import train_test_split
+from fowt_ml.ensemble import EnsembleModel
+
+
+@pytest.fixture
+def regression_data():
+    """Setup regression dataset."""
+    return make_regression(
+        n_samples=100,
+        n_features=5,
+        random_state=0,
+        shuffle=True,
+        n_targets=2,
+    )
+
+
+@pytest.fixture
+def train_test_data(regression_data):
+    x, y = regression_data
+    x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.25)
+    return x_train, x_test, y_train, y_test
+
+
+class TestEnsembleModel:
+    def test_init_random_forest_is_valid_estimator(self):
+        model = EnsembleModel(estimator="RandomForest")
+        assert isinstance(model.estimator, RandomForestRegressor)
+
+    def test_init_extra_trees_is_valid_estimator(self):
+        model = EnsembleModel(estimator="ExtraTrees")
+        assert isinstance(model.estimator, ExtraTreesRegressor)
+
+    def test_init_wrong_estimator_name_raise_error(self):
+        with pytest.raises(ValueError):
+            EnsembleModel(estimator="Linear")
+
+    def test_init_properly_set_estimator_params(self):
+        n_estimators = 10
+        model = EnsembleModel(estimator="RandomForest", n_estimators=n_estimators)
+        assert model.estimator.n_estimators == n_estimators
+
+    def test_init_accept_estimator_instance(self):
+        estimator = RandomForestRegressor()
+        model = EnsembleModel(estimator=estimator)
+        assert isinstance(model.estimator, RandomForestRegressor)
+
+    def test_cross_val_score_results_have_correct_shape(self, regression_data):
+        x, y = regression_data
+        model = EnsembleModel(estimator="RandomForest")
+        n_folds = 3  # default is to use k-fold CV, where k is the number of folds
+        scores = model.cross_val_score(x, y, cv=n_folds)
+        assert len(scores) == n_folds
+
+    def test_cross_val_score_can_accept_custom_scoring(self, regression_data):
+        x, y = regression_data
+        model = EnsembleModel(estimator="RandomForest")
+        scores = model.cross_val_score(x, y, scoring="neg_root_mean_squared_error")
+        # score is negative to make it such that higher is better
+        assert all(scores < 0)
+
+    def test_oob_score_works_with_default_scoring(self, regression_data):
+        x, y = regression_data
+        # oob_score=True means that r2 scoring is used
+        model = EnsembleModel(estimator="RandomForest", oob_score=True)
+        score = model.oob_score(x, y)
+        assert score > 0
+
+    def test_oob_score_automatically_enables_oob_score(self, regression_data):
+        x, y = regression_data
+        model = EnsembleModel(estimator="RandomForest")
+        # model.oob_score sets oob_score to True and raises a warning
+        with pytest.warns():
+            score = model.oob_score(x, y)
+        assert score > 0
+
+    def test_oob_score_works_with_custom_scoring(self, regression_data):
+        x, y = regression_data
+        model = EnsembleModel(estimator="RandomForest")
+        # model.oob_score sets oob_score to custom score metric and raises a warning
+        with pytest.warns():
+            score = model.oob_score(x, y, scoring="neg_root_mean_squared_error")
+        # score is negative to make it such that higher is better
+        assert score < 0
+
+    def test_calculate_score_works_with_default_scoring(self, train_test_data):
+        x_train, x_test, y_train, y_test = train_test_data
+        model = EnsembleModel(estimator="RandomForest")
+        score = model.calculate_score(x_train, y_train, x_test, y_test)
+        # default score is r2
+        assert score > 0
+
+    def test_calculate_score_works_with_custom_scoring(self, train_test_data):
+        x_train, x_test, y_train, y_test = train_test_data
+        model = EnsembleModel(estimator="RandomForest")
+        score = model.calculate_score(
+            x_train,
+            y_train,
+            x_test,
+            y_test,
+            scoring="neg_root_mean_squared_error",
+        )
+        # score is negative to make it such that higher is better
+        assert score < 0
+
+    def test_calculate_score_works_with_multiple_scorings(self, train_test_data):
+        x_train, x_test, y_train, y_test = train_test_data
+        model = EnsembleModel(estimator="RandomForest")
+        scorings = ["r2", "neg_root_mean_squared_error"]
+        scores = model.calculate_score(
+            x_train, y_train, x_test, y_test, scoring=scorings
+        )
+        # a list of scores is returned
+        assert len(scores) == len(scorings)
+        assert all(s in scores for s in scorings)


### PR DESCRIPTION
Closes #5 


Concerning the performance of the predictions using random tree-based models (and others), I remembered a talk that mentioned tools to make model inference more efficient by creating "compiled" models in lower-level languages. I list the tools here, maybe they can become relevant later on, if the performance of the inference becomes crucial: 
* [TL2cgen](https://tl2cgen.readthedocs.io/): "model compiler for decision tree models." "You can convert any decision tree models (random forests, gradient boosting models) into C code and distribute it as a native binary."
* [hummingbird](https://github.com/microsoft/hummingbird) (by Microsoft): "a library for compiling trained traditional ML models into tensor computations." "Currently, you can use Hummingbird to convert your trained traditional ML models into [PyTorch](https://pytorch.org/), [TorchScript](https://pytorch.org/docs/stable/jit.html), [ONNX](https://onnx.ai/), and [TVM](https://docs.tvm.ai/)). Hummingbird [supports](https://github.com/microsoft/hummingbird/wiki/Supported-Operators) a variety of ML models and featurizers. These models include [scikit-learn](https://scikit-learn.org/stable/) Decision Trees and Random Forest, and also [LightGBM](https://github.com/Microsoft/LightGBM) and [XGBoost](https://github.com/dmlc/xgboost) Classifiers/Regressors. Support for other neural network backends and models is on our [roadmap](https://github.com/microsoft/hummingbird/wiki/Roadmap-for-Upcoming-Features-and-Support)."
* [lleaves](https://github.com/siboehm/lleaves): "lleaves converts trained LightGBM models to optimized machine code, speeding-up prediction by ≥10x."